### PR TITLE
fixed discarded_users.migration

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -10,11 +10,18 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # end
 
   # POST /resource
-  # def create
-  #   super
-  #   :address=Address.new(address_params)
+  def create
+    super
+    address=Address.new(address_params)
+    address.user_id=resource.id
+    address.address=resource.address
+    address.first_name=resource.first_name
+    address.last_name=resource.last_name
+    address.telephone_number=resource.telephone_number
+    address.post_number=resource.post_number
+    address.save
 
-  # end
+  end
 
   # GET /resource/edit
   # def edit
@@ -61,8 +68,8 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # def after_inactive_sign_up_path_for(resource)
   #   super(resource)
   # end
-  # private
-  # def address_params
-  #   params.require(:address).permit(:user_id,:address,:first_name,:last_name,:telephone_number,:post_number)
-  # end
+  private
+  def address_params
+    params.require(:address).permit(:user_id,:address,:first_name,:last_name,:telephone_number,:post_number)
+  end
 end

--- a/db/migrate/20190908205357_add_discarded_at_to_users.rb
+++ b/db/migrate/20190908205357_add_discarded_at_to_users.rb
@@ -1,6 +1,6 @@
 class AddDiscardedAtToUsers < ActiveRecord::Migration[5.2]
    def change
-    add_column :posts, :discarded_at, :datetime
-    add_index :posts, :discarded_at
+    add_column :users, :discarded_at, :datetime
+    add_index :users, :discarded_at
   end
 end


### PR DESCRIPTION
db/migrate/...add_discarded_at_to_users.rbの記述を

add_column :discarded_at, :datetime
add_index :discarded_at

から

add_column :users, :discarded_at, :datetime
add_index :users, :discarded_at

に修正。追加先のモデルの記述がなかったためエラーが発生したものと思われ