### PR TITLE
fixed stock & address select

### DIFF
--- a/app/views/admin/products/show.html.erb
+++ b/app/views/admin/products/show.html.erb
@@ -19,7 +19,7 @@
                 </tr>
                 <tr>
                     <td>レーベル名</td>
-                    <td><%=@product.label.name%></td>s
+                    <td><%=@product.label.name%></td>
                 </tr>
                 <tr>
                     <td>ジャンル名</td>
@@ -52,7 +52,11 @@
                 </tr>
                 <tr>
                     <td>ステータス</td>
-                    <td><%=@product.is_selling%></td>
+                    <%if @product.is_selling%>
+                        <td>販売中</td>
+                    <%else%>
+                        <td>販売中止</td>
+                    <%end%>
                 </tr>
             </table>
             <div class="contetns_end_group">

--- a/app/views/cart_items/index.html.erb
+++ b/app/views/cart_items/index.html.erb
@@ -36,8 +36,17 @@
               .id), class: "btn btn-primary" %>
               <% end %>
             <span class = "amount"><%= cart_item.order_number %>枚</span>
-            <%= link_to "+", cart_items_plus_path(cart_item_id: cart_item
-            .id), class: "btn btn-primary" %>
+            <!--在庫確認-->
+            <%@ZAN=0%>
+            <%cart_items2 = CartItem.where(product_id: cart_item.product_id)%>
+            <%cart_items2.each do |cut|%>
+              <%@ZAN += cut.order_number%>
+            <%end%>
+            <!--おしまい-->
+            <%if cart_item.product.stock_quantity>=(@ZAN.to_i+1)%>
+              <%= link_to "+", cart_items_plus_path(cart_item_id: cart_item
+              .id), class: "btn btn-primary" %>
+            <%end%>
             </td>
             <td><%= link_to "取り消し", cart_item_path(cart_item),method: :delete,class: "pp btn btn-danger" %></td>
           </tr>

--- a/app/views/cart_items/new.html.erb
+++ b/app/views/cart_items/new.html.erb
@@ -5,6 +5,9 @@
             <div class="col-xs-12">
                 <div class = "address_mode_select">
                     <h2>配送設定</h2>
+                    <% if flash[:notice] %>
+                        <%= flash[:notice] %><br>
+                    <% end %>
                     <%= f.radio_button :method_of_mode, "新規作成",name: "radiradi" %>新規作成
                     <%= f.radio_button :method_of_mode, "住所の選択",name: "radiradi" %>住所の選択
                 </div>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -35,21 +35,32 @@
             <% end %>
         <br><%=@product.label.name %><br>
         <%=@product.genre.name %><br>
-        <% if user_signed_in? %>
-            <% judge=0 %>
-            <% @cart_items.each do |cart_item| %>
-                <% if cart_item.product_id == @product.id %>
-                    <%= link_to 'カートに入れる', cart_items_adding_path(cart_item_id: cart_item.id),class: "btn-border" %>
-                    <% judge=1 %>
-                    <% break %>
+        <!--在庫確認-->
+            <%@ZAN=0%>
+            <%cart_items2 = CartItem.where(product_id: @product.id)%>
+            <%cart_items2.each do |cut|%>
+              <%@ZAN += cut.order_number%>
+            <%end%>
+            <!--おしまい-->
+        <% if @product.stock_quantity>0+@ZAN%>
+            <% if user_signed_in? %>
+                <% judge=0 %>
+                <% @cart_items.each do |cart_item| %>
+                    <% if cart_item.product_id == @product.id %>
+                        <%= link_to 'カートに入れる', cart_items_adding_path(cart_item_id: cart_item.id),class: "btn-border" %>
+                        <% judge=1 %>
+                        <% break %>
+                    <% end %>
                 <% end %>
+                <% if judge == 0%>
+                    <%= link_to 'カートに入れる',cart_items_path(product_id: @product.id),method: :post,class: "btn-border" %>
+                <% end %>
+            <% else %>
+                <%= link_to 'カートに入れる', new_user_session_path,class: "btn-border" %>
             <% end %>
-            <% if judge == 0%>
-                 <%= link_to 'カートに入れる',cart_items_path(product_id: @product.id),method: :post,class: "btn-border" %>
-            <% end %>
-        <% else %>
-            <%= link_to 'カートに入れる', new_user_session_path,class: "btn-border" %>
-        <% end %>
+        <%else%>
+            売り切れ、ごめん
+        <%end%>
     </div>
     </div>
     </div>


### PR DESCRIPTION
在庫が足りない際
・商品詳細ページのカート追加ボタンが消える
・カート一覧で商品を追加する+ボタンが表示されない
機能を追加（全ユーザーのカートアイテムも踏まえて判断している）

住所を選択していない場合、購入処理を完了できないよう修正、新規登録時の情報不足の際のエラーは修正できていません。